### PR TITLE
[fixes #6168242] allows scalr to figure out what the right index is for

### DIFF
--- a/bin/ttmscalr
+++ b/bin/ttmscalr
@@ -1080,7 +1080,10 @@ Main {
     end
 
     def run
-      params['server'] = Value.new('debug.1')
+      options = Scalr::Caller.collect_options(params, [:farm_id])
+      exec_role = fetch_role_for_script(options,'debug')
+      role_index = exec_role.first[:servers].first[:index]
+      params['server'] = Value.new("debug.#{role_index}")
       ssher = Scalr::Ssher.new(params)
       ssher.execute('-t "source /etc/profile.d/TTM.ENV.sh; if [[ -f /etc/profile.d/rvm.sh ]]; then source /etc/profile.d/rvm.sh; fi; cd /var/www; rails console"')
       exit_status ssher.exit_status


### PR DESCRIPTION
the devdebug server when running the rails_c command
