### PR TITLE
return non-zero exit code if the deploy wasn't a success

### DIFF
--- a/lib/scalr/deployer.rb
+++ b/lib/scalr/deployer.rb
@@ -115,6 +115,7 @@ module Scalr
                monitor.summaries.join("\n")
         end
       end
+      exit 1 unless all_ok
     end
 
   private


### PR DESCRIPTION
This is so that we can detect scalr failures when being called by another script
