### PR TITLE
Preventing empty config lines from crashing script

### DIFF
--- a/lib/scalr/ttm.rb
+++ b/lib/scalr/ttm.rb
@@ -106,7 +106,7 @@ module Scalr
     h = {}
     File.readlines(filename).each do |line|
       key, value = line.strip.split(/\s*=\s*/, 2)
-      h[key.downcase.to_sym] = value
+      h[key.downcase.to_sym] = value if key
     end
     h
   end


### PR DESCRIPTION
If you had an empty third line in your config file the script would throw an exception and die.
This will just check to ensure there is actually a key before trying to use it.
## To Test:
- [ ] Add a blank line to your `.ttm_scalr_access_info` file at the end (or anywhere)
- [ ] Run a scalr command
- [ ] Observe that it succeeded
