### PR TITLE
Handle a case where we get a response without any content.

### DIFF
--- a/lib/scalr/server_deployment.rb
+++ b/lib/scalr/server_deployment.rb
@@ -118,10 +118,13 @@ module Scalr
       if response.content.respond_to?(:failure?) && response.content.failure?
         mark_failed
       end
-      changes = response.content.
+      changes = 0
+      unless response.content.nil?
+        changes = response.content.
           find_all {|log_item| log_item.after?(@last_seen)}.
           map {|log_item| add_log(log_item)}.
           inject(0) {|sum, log_added| sum + log_added}
+      end
       @scans_without_change = changes > 0 ? 0 : @scans_without_change + 1
     end
   end


### PR DESCRIPTION
I'm not sure what to do with this case, but instead of erroring out,
i think it is safe to just count this as a scan without changes

## Problem

Every once in awhile, maybe once a week, we get this stacktrace while deploying

```
+ /root/tools/scalr/bin/ttmscalr deploy production
F, [2015-11-30T16:04:43.220393 #7724] FATAL -- : undefined method `find_all' for nil:NilClass (NoMethodError)
/root/tools/scalr/lib/scalr/server_deployment.rb:122:in `process_log_response'
/root/tools/scalr/lib/scalr/server_deployment.rb:107:in `block in fetch_logs'
/root/tools/scalr/lib/scalr/server_deployment.rb:105:in `each'
/root/tools/scalr/lib/scalr/server_deployment.rb:105:in `fetch_logs'
/root/tools/scalr/lib/scalr/server_deployment.rb:78:in `scan_logs'
/root/tools/scalr/lib/scalr/deployment_monitor.rb:108:in `block in accumulate_logs'
/root/tools/scalr/lib/scalr/deployment_monitor.rb:108:in `each'
/root/tools/scalr/lib/scalr/deployment_monitor.rb:108:in `accumulate_logs'
/root/tools/scalr/lib/scalr/deployment_monitor.rb:35:in `poll'
/root/tools/scalr/lib/scalr/deployer.rb:95:in `block (2 levels) in poll_monitors'
/root/tools/scalr/lib/scalr/deployer.rb:95:in `each'
/root/tools/scalr/lib/scalr/deployer.rb:95:in `block in poll_monitors'
/usr/local/rvm/gems/ruby-2.1.5/gems/activesupport-4.2.1/lib/active_support/core_ext/range/each.rb:7:in `each'
/usr/local/rvm/gems/ruby-2.1.5/gems/activesupport-4.2.1/lib/active_support/core_ext/range/each.rb:7:in `each_with_time_with_zone'
/root/tools/scalr/lib/scalr/deployer.rb:90:in `poll_monitors'
/root/tools/scalr/lib/scalr/deployer.rb:66:in `execute'
/root/tools/scalr/bin/ttmscalr:256:in `run'
/usr/local/rvm/gems/ruby-2.1.5/gems/main-6.1.0/lib/main/program/class_methods.rb:156:in `block in run'
/usr/local/rvm/gems/ruby-2.1.5/gems/main-6.1.0/lib/main/program/class_methods.rb:145:in `catch'
/usr/local/rvm/gems/ruby-2.1.5/gems/main-6.1.0/lib/main/program/class_methods.rb:145:in `run'
/usr/local/rvm/gems/ruby-2.1.5/gems/main-6.1.0/lib/main/factories.rb:18:in `run'
/usr/local/rvm/gems/ruby-2.1.5/gems/main-6.1.0/lib/main/factories.rb:25:in `Main'
/root/tools/scalr/bin/ttmscalr:122:in `<main>'
```

## Solution

Count a response without any content as a response without any changes.  I'm not sure why we are getting a response without content, but I think in this case, it is safe to just let this count that as no changes found, and it should poll again.


