### PR TITLE
Better tunnel

### DIFF
--- a/bin/ttmscalr
+++ b/bin/ttmscalr
@@ -1216,6 +1216,12 @@ Main {
       description 'Farm to connect to'
     end
 
+    option 'port, -p' do
+      argument :optional
+      cast :int
+      description 'Local port to host the tunnel'
+    end
+
     def run
       response = dispatch(:global_variables_list, params)
       return if generic_error(response)
@@ -1224,12 +1230,12 @@ Main {
       db_conn = db_string.to_s.split("@")
       db_host = db_conn[1].split("/")[0]
 
-      options = Scalr::Caller.collect_options(params, [:farm_id])
+      options = Scalr::Caller.collect_options(params, [:farm_id, :port])
       exec_role = fetch_role_for_script(options,'debug')
       role_index = exec_role.first[:servers].first[:index]
       params['server'] = Value.new("debug.#{role_index}")
       ssher = Scalr::Ssher.new(params)
-      ssher.open_db_tunnel(db_host)
+      ssher.open_db_tunnel(db_host, options[:port])
       exit_status ssher.exit_status
     end
   end

--- a/bin/ttmscalr
+++ b/bin/ttmscalr
@@ -1233,7 +1233,7 @@ Main {
       db_host, db_name = db_conn[1].split("/")
 
       options = Scalr::Caller.collect_options(params, [:farm_id, :port])
-      port    = options[:port]
+      port    = options[:port] || 5434
 
       exec_role = fetch_role_for_script(options,'debug')
       role_index = exec_role.first[:servers].first[:index]

--- a/bin/ttmscalr
+++ b/bin/ttmscalr
@@ -1227,15 +1227,22 @@ Main {
       return if generic_error(response)
 
       db_string = response.content.find{|var| var.name_equals?("TTM_DATABASE_URL")} || response.content.find{|var| var.name_equals?("TTM_WAREHOUSE_DATABASE_URL")}
-      db_conn = db_string.to_s.split("@")
-      db_host = db_conn[1].split("/")[0]
+
+      db_conn  = db_string.to_s.split("@")
+      db_creds = db_conn[0].split("postgres://")[1]
+      db_host, db_name = db_conn[1].split("/")
 
       options = Scalr::Caller.collect_options(params, [:farm_id, :port])
+      port    = options[:port]
+
       exec_role = fetch_role_for_script(options,'debug')
       role_index = exec_role.first[:servers].first[:index]
       params['server'] = Value.new("debug.#{role_index}")
+
+      psql_command = "psql postgres://#{db_creds}@localhost:#{port}/#{db_name}"
+
       ssher = Scalr::Ssher.new(params)
-      ssher.open_db_tunnel(db_host, options[:port])
+      ssher.open_db_tunnel(db_host, psql_command, port)
       exit_status ssher.exit_status
     end
   end

--- a/lib/scalr/ssher.rb
+++ b/lib/scalr/ssher.rb
@@ -27,9 +27,9 @@ module Scalr
       exec command
     end
 
-    def open_db_tunnel(db_host)
+    def open_db_tunnel(db_host, port = 5433)
       return unless db_host
-      tunnel( "5433:#{db_host}")
+      tunnel("#{port}:#{db_host}")
     end
 
     def execute_in_www_dir(remote_command )

--- a/lib/scalr/ssher.rb
+++ b/lib/scalr/ssher.rb
@@ -17,19 +17,27 @@ module Scalr
       exec command
     end
 
-    def tunnel(tunnel_spec)
+    def tunnel(tunnel_spec, after_command)
       return unless identify_server
       return unless check_key_path
 
       cmd = params.has_key?('cmd') ? params['cmd'].value : 'ssh'
       command = "#{cmd} -i #{key_path} -L #{tunnel_spec} -N root@#{server.external_ip}"
       puts "Executing `#{command}`"
+
+      if after_command
+        puts ""
+        puts "Leave this program running, and run this command in another shell:"
+        puts "#{after_command}"
+        puts ""
+      end
+
       exec command
     end
 
-    def open_db_tunnel(db_host, port = 5433)
+    def open_db_tunnel(db_host, psql_command, port = 5433)
       return unless db_host
-      tunnel("#{port}:#{db_host}")
+      tunnel("#{port}:#{db_host}", psql_command)
     end
 
     def execute_in_www_dir(remote_command )


### PR DESCRIPTION
I'm working from home today, and working with the tunnel is rough. Especially when I'm trying to jump between the apangea db and the warehouse db.

This PR does two things:

- [ ] Lets you start a tunnel on a specific port (so you can have more than one running.)
- [ ] Tells you the psql command to run after establishing the tunnel.