### PR TITLE
change version number to use when creating scalr gem. Fix bash export…

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -12,7 +12,7 @@
   gemsets in which you'd like to use ttmscalr.
 * Build and install the scalr gem:
   * `gem build scalr.gemspec`
-  * `gem install ./scalr-0.2.3.gem`
+  * `gem install ./scalr-0.2.28.gem`
 * Get and configure API credentials (see: [Scalr API Credentials](#scalr-api-credentials))
 * Now you should be able to run `ttmscalr farm:list`
 
@@ -31,7 +31,7 @@ For a more permanent solution you might have in your `~/.bashrc` or
     NODE_HOME=~/tools/node/current
     ...
 
-    export PATH=~/bin:$SCALR_HOME/bin:$NODE_HOME/bin
+    export PATH=~/bin:$SCALR_HOME/bin:$NODE_HOME/bin:$PATH
 
 ### Scalr API Credentials
 


### PR DESCRIPTION
Superficial changes to version number and PATH export in setup instructions. Let me know if you have any questions!