### PR TITLE
Too many authentication failures for root

### DIFF
--- a/lib/scalr/ssher.rb
+++ b/lib/scalr/ssher.rb
@@ -12,7 +12,7 @@ module Scalr
       return unless check_key_path
 
       cmd = params.has_key?('cmd') ? params['cmd'].value : 'ssh'
-      command = "#{cmd} -i #{key_path} root@#{server.external_ip} #{remote_command}"
+      command = "#{cmd} -i #{key_path} -o 'IdentitiesOnly yes' root@#{server.external_ip} #{remote_command}"
       puts "Executing `#{command}`"
       exec command
     end


### PR DESCRIPTION
I wasn't able to ssh onto our farms using scalr at times.

```
IM :> ttmscalr ssh jenkinsminion.1 -f ttm-jenkins
Executing ssh -i /Users/andrew.patterson/.ssh/FARM-21876.us-east-1.private.pem root@54.91.165.44 
The authenticity of host '54.91.165.44 (54.91.165.44)' can't be established.
ECDSA key fingerprint is SHA256:baUBv6S68jQDaTxX4fsOF8AZFHEW/LJPwSmcZVfiXfw.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '54.91.165.44' (ECDSA) to the list of known hosts.
Received disconnect from 54.91.165.44 port 22:2: Too many authentication failures for root
Disconnected from 54.91.165.44 port 22
```

The problem and fix: https://superuser.com/questions/187779/too-many-authentication-failures-for-username